### PR TITLE
Fix MCP deployment: endpoint URL, allowed host, and /mcp redirect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ ENV TZ=Asia/Jerusalem
 ENV PYTHONPATH=/home/app
 ENV DOCKER_MODE=true
 # Enable MCP Host-header (DNS-rebinding) validation for the deployed host.
-ENV MCP_ALLOWED_HOSTS='["zmanim.ginzburg.io", "localhost:*"]'
+ENV MCP_ALLOWED_HOSTS='["api.ginzburg.io", "localhost:*"]'
 EXPOSE 8000
 CMD ["uv", "run", "python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ nothing extra needs to be started — running the API serves the MCP endpoint to
 ### Connecting a client
 
 This is a **streamable-HTTP** server, so point clients at the `/mcp` URL —
-`https://zmanim.ginzburg.io/mcp` for the hosted instance (or `http://localhost:8000/mcp`
+`http://api.ginzburg.io/il_transport/mcp` for the hosted instance (or `http://localhost:8000/mcp`
 when running locally). Below are configs for the most popular MCP clients.
 
 #### Claude Code
 
 ```sh
-claude mcp add --transport http israel-transport https://zmanim.ginzburg.io/mcp
+claude mcp add --transport http israel-transport http://api.ginzburg.io/il_transport/mcp
 ```
 
 #### Claude Desktop
@@ -50,7 +50,7 @@ For older versions whose `claude_desktop_config.json` only speaks stdio, bridge 
   "mcpServers": {
     "israel-transport": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://zmanim.ginzburg.io/mcp"]
+      "args": ["-y", "mcp-remote", "http://api.ginzburg.io/il_transport/mcp"]
     }
   }
 }
@@ -60,9 +60,9 @@ For older versions whose `claude_desktop_config.json` only speaks stdio, bridge 
 
 ChatGPT connects to remote MCP servers as **custom connectors** (available on paid
 plans). Enable **Settings → Connectors → Advanced → Developer mode**, then **Add custom
-connector** and paste the server URL `https://zmanim.ginzburg.io/mcp`. ChatGPT cannot run
-local stdio servers and requires a public **HTTPS** endpoint, so the hosted URL (not
-`localhost`) must be used.
+connector** and paste the server URL `https://api.ginzburg.io/il_transport/mcp`. ChatGPT cannot
+run local stdio servers and requires a public **HTTPS** endpoint (note the `https://` — a
+plain-`http` URL or `localhost` will not be accepted).
 
 #### Codex
 
@@ -73,7 +73,7 @@ In `~/.codex/config.toml` (HTTP transport requires the rmcp client feature):
 experimental_use_rmcp_client = true
 
 [mcp_servers.israel-transport]
-url = "https://zmanim.ginzburg.io/mcp"
+url = "http://api.ginzburg.io/il_transport/mcp"
 ```
 
 #### VS Code (GitHub Copilot agent mode)
@@ -85,7 +85,7 @@ In `.vscode/mcp.json`:
   "servers": {
     "israel-transport": {
       "type": "http",
-      "url": "https://zmanim.ginzburg.io/mcp"
+      "url": "http://api.ginzburg.io/il_transport/mcp"
     }
   }
 }
@@ -98,7 +98,7 @@ In `.vscode/mcp.json`:
   "mcpServers": {
     "israel-transport": {
       "type": "http",
-      "url": "https://zmanim.ginzburg.io/mcp"
+      "url": "http://api.ginzburg.io/il_transport/mcp"
     }
   }
 }
@@ -111,5 +111,5 @@ running behind a reverse proxy. To enable it, set `MCP_ALLOWED_HOSTS` (and optio
 `MCP_ALLOWED_ORIGINS`) as JSON arrays — `"host:*"` port wildcards are supported:
 
 ```
-MCP_ALLOWED_HOSTS='["zmanim.ginzburg.io", "localhost:*"]'
+MCP_ALLOWED_HOSTS='["api.ginzburg.io", "localhost:*"]'
 ```


### PR DESCRIPTION
Fixes the deployed MCP server, which left Claude Code stuck on "connecting".

## 1. Trailing-slash redirect (the connection hang)

The streamable-HTTP sub-app was mounted at `/mcp` while its own route was at `/`, so Starlette `307`-redirected `/mcp` → `/mcp/`. Behind the `/il_transport` path-stripping reverse proxy, that redirect's `Location` dropped the prefix (`/mcp/` instead of `/il_transport/mcp/`), so the client looped on connecting.

Fix: set `streamable_http_path="/mcp"` and mount the MCP app at the root. `/mcp` now serves directly (`200`, no redirect). FastAPI's own routes and docs are matched first, so mounting at `/` does not shadow them.

Verified against the real app (session manager running): `POST /mcp` → `200` handshake, `GET /` → docs, unknown paths → `404`, wrong Host → `421`.

## 2. Endpoint URL / allowed host

The deployed endpoint is `http://api.ginzburg.io/il_transport/mcp` (host `api.ginzburg.io` behind the `/il_transport` prefix), not `zmanim.ginzburg.io`.

- README: update all client connection examples.
- Dockerfile: `MCP_ALLOWED_HOSTS` host → `api.ginzburg.io`.
- ChatGPT example uses the `https://` form, since ChatGPT custom connectors require HTTPS.