### PR TITLE
Make MCP work behind the nginx reverse proxy (redirect + JSON responses)

### DIFF
--- a/israel_transport_api/main.py
+++ b/israel_transport_api/main.py
@@ -46,8 +46,10 @@ app.include_router(stops_router)
 app.include_router(routes_router)
 app.include_router(siri_router)
 
-# Expose the same operations over the Model Context Protocol at /mcp.
-app.mount('/mcp', mcp_server.mcp.streamable_http_app())
+# Expose the same operations over the Model Context Protocol. The MCP app is mounted
+# at the root and serves its endpoint at /mcp (see mcp_server for why this avoids a
+# trailing-slash redirect); FastAPI's own routes and docs are matched first.
+app.mount('/', mcp_server.mcp.streamable_http_app())
 
 if __name__ == '__main__':
     if sys.platform == "win32":

--- a/israel_transport_api/mcp_server.py
+++ b/israel_transport_api/mcp_server.py
@@ -20,12 +20,14 @@ from israel_transport_api.siri.siri_models import VehicleLocation
 
 logger = logging.getLogger('mcp_server')
 
-# stateless_http + a root streamable path so that mounting at "/mcp" exposes the
-# endpoint exactly at "/mcp" (rather than "/mcp/mcp").
+# The streamable endpoint lives at "/mcp"; the app is mounted at the root (see
+# main.py). Mounting the sub-app at "/mcp" instead would leave its route at "/",
+# which makes Starlette 307-redirect "/mcp" -> "/mcp/" — and behind a path-stripping
+# reverse proxy that redirect drops the prefix and the client never connects.
 mcp = FastMCP(
     'Israel public transport',
     stateless_http=True,
-    streamable_http_path='/',
+    streamable_http_path='/mcp',
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=bool(env.MCP_ALLOWED_HOSTS),
         allowed_hosts=env.MCP_ALLOWED_HOSTS,


### PR DESCRIPTION
Two fixes so the deployed MCP server actually connects (it was hanging Claude Code to a 30s timeout). Follow-up to #12, which merged before these were pushed.

## 1. Trailing-slash redirect (was: HTTP 307 loop)

Mounting the streamable-HTTP sub-app at `/mcp` left its route at `/`, so Starlette `307`-redirected `/mcp` → `/mcp/`; behind the `/il_transport` path-stripping proxy the redirect dropped the prefix and the client looped. Fix: `streamable_http_path="/mcp"` + mount at root. `/mcp` now serves directly (`200`). FastAPI routes/docs are matched first.

## 2. SSE responses (was: 30s connection timeout)

POST responses defaulted to `text/event-stream`. Through nginx, that streaming content type buffers/stalls and the client never receives the handshake response. This server has no server-initiated messages, so `json_response=True` makes POSTs return a plain `application/json` body with `Content-Length` — proxies forward it cleanly.

Verified locally with the real `mcp` streamable-HTTP client: `POST /mcp` → `200 application/json`, `initialize` + `tools/list` succeed.

## Deploy notes

Recommended nginx `location` for `/il_transport/`:

```nginx
location /il_transport/ {
    proxy_pass http://transport_api:8000/;
    proxy_set_header Host $host;
    proxy_http_version 1.1;
    proxy_set_header Connection "";
    proxy_buffering off;
    proxy_read_timeout 3600s;
}
```

After deploying, remove and re-add the server in Claude Code to clear stale reconnect state.