### PR TITLE
Return JSON MCP responses for reverse-proxy compatibility

### DIFF
--- a/israel_transport_api/mcp_server.py
+++ b/israel_transport_api/mcp_server.py
@@ -27,6 +27,11 @@ logger = logging.getLogger('mcp_server')
 mcp = FastMCP(
     'Israel public transport',
     stateless_http=True,
+    # Reply to POSTs with plain application/json instead of an SSE stream. This server
+    # has no server-initiated messages, and JSON responses survive reverse proxies
+    # (e.g. nginx) cleanly, whereas buffered text/event-stream responses can hang the
+    # client until it times out.
+    json_response=True,
     streamable_http_path='/mcp',
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=bool(env.MCP_ALLOWED_HOSTS),


### PR DESCRIPTION
POST responses defaulted to text/event-stream (SSE). Behind nginx that streaming content type buffers/stalls and the client hangs until it times out. This server has no server-initiated messages, so set json_response=True: POSTs now return a plain application/json body with Content-Length, which proxies forward cleanly.