### PR TITLE
Stop reverse-proxy buffering of MCP SSE responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ nothing extra needs to be started — running the API serves the MCP endpoint to
 ### Connecting a client
 
 This is a **streamable-HTTP** server, so point clients at the `/mcp` URL —
-`http://api.ginzburg.io/il_transport/mcp` for the hosted instance (or `http://localhost:8000/mcp`
+`https://api.ginzburg.io/il_transport/mcp` for the hosted instance (or `http://localhost:8000/mcp`
 when running locally). Below are configs for the most popular MCP clients.
 
 #### Claude Code
 
 ```sh
-claude mcp add --transport http israel-transport http://api.ginzburg.io/il_transport/mcp
+claude mcp add --transport http israel-transport https://api.ginzburg.io/il_transport/mcp
 ```
 
 #### Claude Desktop
@@ -50,7 +50,7 @@ For older versions whose `claude_desktop_config.json` only speaks stdio, bridge 
   "mcpServers": {
     "israel-transport": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "http://api.ginzburg.io/il_transport/mcp"]
+      "args": ["-y", "mcp-remote", "https://api.ginzburg.io/il_transport/mcp"]
     }
   }
 }
@@ -73,7 +73,7 @@ In `~/.codex/config.toml` (HTTP transport requires the rmcp client feature):
 experimental_use_rmcp_client = true
 
 [mcp_servers.israel-transport]
-url = "http://api.ginzburg.io/il_transport/mcp"
+url = "https://api.ginzburg.io/il_transport/mcp"
 ```
 
 #### VS Code (GitHub Copilot agent mode)
@@ -85,7 +85,7 @@ In `.vscode/mcp.json`:
   "servers": {
     "israel-transport": {
       "type": "http",
-      "url": "http://api.ginzburg.io/il_transport/mcp"
+      "url": "https://api.ginzburg.io/il_transport/mcp"
     }
   }
 }
@@ -98,7 +98,7 @@ In `.vscode/mcp.json`:
   "mcpServers": {
     "israel-transport": {
       "type": "http",
-      "url": "http://api.ginzburg.io/il_transport/mcp"
+      "url": "https://api.ginzburg.io/il_transport/mcp"
     }
   }
 }

--- a/israel_transport_api/config.py
+++ b/israel_transport_api/config.py
@@ -1,5 +1,8 @@
-from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+import json
+from typing import Annotated
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict, NoDecode
 
 
 class Env(BaseSettings):
@@ -18,11 +21,21 @@ class Env(BaseSettings):
 
     # MCP DNS-rebinding protection. When MCP_ALLOWED_HOSTS is non-empty, the mounted
     # /mcp endpoint validates the Host header against this allow-list (supports
-    # "host:*" port wildcards). Empty (default) disables the check, which is
+    # "host:*" port wildcards). Empty/unset (default) disables the check, which is
     # appropriate when the service runs behind a reverse proxy. Provide values as a
     # JSON array, e.g. MCP_ALLOWED_HOSTS='["example.com", "localhost:*"]'.
-    MCP_ALLOWED_HOSTS: list[str] = Field(default_factory=list)
-    MCP_ALLOWED_ORIGINS: list[str] = Field(default_factory=list)
+    MCP_ALLOWED_HOSTS: Annotated[list[str], NoDecode] = Field(default_factory=list)
+    MCP_ALLOWED_ORIGINS: Annotated[list[str], NoDecode] = Field(default_factory=list)
+
+    @field_validator('MCP_ALLOWED_HOSTS', 'MCP_ALLOWED_ORIGINS', mode='before')
+    @classmethod
+    def _parse_host_list(cls, v):
+        # NoDecode hands us the raw env string; treat blank as "no allow-list" rather
+        # than letting an empty value blow up JSON parsing.
+        if isinstance(v, str):
+            v = v.strip()
+            return json.loads(v) if v else []
+        return v
 
 
 env = Env()

--- a/israel_transport_api/main.py
+++ b/israel_transport_api/main.py
@@ -46,6 +46,10 @@ app.include_router(stops_router)
 app.include_router(routes_router)
 app.include_router(siri_router)
 
+# Keep reverse proxies (nginx) from buffering the MCP SSE responses, which otherwise
+# stalls the client's handshake. Must wrap the mount, so add it before mounting.
+app.add_middleware(mcp_server.DisableProxyBuffering)
+
 # Expose the same operations over the Model Context Protocol. The MCP app is mounted
 # at the root and serves its endpoint at /mcp (see mcp_server for why this avoids a
 # trailing-slash redirect); FastAPI's own routes and docs are matched first.

--- a/israel_transport_api/main.py
+++ b/israel_transport_api/main.py
@@ -47,7 +47,8 @@ app.include_router(routes_router)
 app.include_router(siri_router)
 
 # Keep reverse proxies (nginx) from buffering the MCP SSE responses, which otherwise
-# stalls the client's handshake. Must wrap the mount, so add it before mounting.
+# stalls the client's handshake. add_middleware wraps the whole app, mounts included,
+# regardless of call order.
 app.add_middleware(mcp_server.DisableProxyBuffering)
 
 # Expose the same operations over the Model Context Protocol. The MCP app is mounted

--- a/israel_transport_api/mcp_server.py
+++ b/israel_transport_api/mcp_server.py
@@ -44,6 +44,32 @@ mcp = FastMCP(
 _conn: AsyncConnection | None = None
 
 
+class DisableProxyBuffering:
+    """ASGI middleware that adds ``X-Accel-Buffering: no`` to MCP responses.
+
+    The MCP client opens a long-lived GET SSE stream and waits for its response
+    headers before it will POST ``initialize``. A buffering reverse proxy (nginx's
+    default) holds those headers back, so the client never proceeds and times out.
+    This header tells nginx not to buffer the response even when ``proxy_buffering``
+    is on, so the fix doesn't depend on the proxy being configured correctly.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope['type'] != 'http' or not scope.get('path', '').startswith('/mcp'):
+            return await self.app(scope, receive, send)
+
+        async def send_wrapper(message):
+            if message['type'] == 'http.response.start':
+                headers = message.setdefault('headers', [])
+                headers.append((b'x-accel-buffering', b'no'))
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
 def set_connection(conn: AsyncConnection) -> None:
     global _conn
     _conn = conn

--- a/israel_transport_api/mcp_server.py
+++ b/israel_transport_api/mcp_server.py
@@ -58,7 +58,13 @@ class DisableProxyBuffering:
         self.app = app
 
     async def __call__(self, scope, receive, send):
-        if scope['type'] != 'http' or not scope.get('path', '').startswith('/mcp'):
+        # Strip any root_path prefix so the check works whether or not the reverse
+        # proxy strips the deployment prefix (e.g. /il_transport) before the app.
+        path = scope.get('path', '')
+        root_path = scope.get('root_path', '')
+        if root_path and path.startswith(root_path):
+            path = path[len(root_path):]
+        if scope['type'] != 'http' or not path.startswith('/mcp'):
             return await self.app(scope, receive, send)
 
         async def send_wrapper(message):


### PR DESCRIPTION
## Root cause (diagnosed with the real client)

I ran the actual Claude Code `http` MCP client against a logging mock and captured the wire behavior: the client **opens the GET SSE stream first and only POSTs `initialize` after it receives that stream's response headers**. Behind nginx with buffering on (the default), those headers are held back, so the client never POSTs and times out at 30s — matching the deployed log (`GET /mcp 200`, no POST, terminate every 30s).

## Changes

- **`X-Accel-Buffering: no` middleware** on `/mcp` responses, so nginx streams them even when `proxy_buffering` is on. Defense-in-depth — the proper nginx fix is still `proxy_buffering off`.
- **Hardened `MCP_ALLOWED_HOSTS`/`MCP_ALLOWED_ORIGINS` parsing** (`NoDecode`): a blank env value now means "no allow-list" instead of crashing the app on JSON parse.

## The required nginx change (not in this repo)

The decisive fix is on the proxy. The `location` for `/il_transport/` must include:

```nginx
proxy_buffering off;
proxy_http_version 1.1;
proxy_set_header Host $host;
proxy_read_timeout 3600s;
```

Verify buffering with: `curl -N -i --max-time 6 -H "Accept: text/event-stream" http://api.ginzburg.io/il_transport/mcp` — headers should appear **immediately**; if it hangs with no output, the proxy is still buffering.